### PR TITLE
Fix/improve grouped bar performance

### DIFF
--- a/packages/bar/src/compute/common.js
+++ b/packages/bar/src/compute/common.js
@@ -33,4 +33,9 @@ export const normalizeData = (data, keys) =>
     }))
 
 export const filterNullValues = data =>
-    Object.keys(data).reduce((acc, key) => (data[key] ? { ...acc, [key]: data[key] } : acc), {})
+    Object.keys(data).reduce((acc, key) => {
+        if (data[key]) {
+            acc[key] = data[key]
+        }
+        return acc
+    }, {})

--- a/packages/bar/src/compute/grouped.js
+++ b/packages/bar/src/compute/grouped.js
@@ -47,14 +47,14 @@ const generateVerticalGroupedBars = (
     const bars = flatten(
         keys.map((key, i) =>
             range(0, xScale.domain().length).map(index => {
-                const x = xScale(getIndex(cleanedData[index])) + barWidth * i + innerPadding * i
-                const y = getY(cleanedData[index][key])
-                const barHeight = getHeight(cleanedData[index][key], y)
+                const x = xScale(getIndex(data[index])) + barWidth * i + innerPadding * i
+                const y = getY(data[index][key])
+                const barHeight = getHeight(data[index][key], y)
                 const barData = {
                     id: key,
-                    value: cleanedData[index][key],
+                    value: data[index][key],
                     index,
-                    indexValue: getIndex(cleanedData[index]),
+                    indexValue: getIndex(data[index]),
                     data: cleanedData[index],
                 }
 
@@ -104,14 +104,14 @@ const generateHorizontalGroupedBars = (
     const bars = flatten(
         keys.map((key, i) =>
             range(0, yScale.domain().length).map(index => {
-                const x = getX(cleanedData[index][key])
-                const y = yScale(getIndex(cleanedData[index])) + barHeight * i + innerPadding * i
-                const barWidth = getWidth(cleanedData[index][key], x)
+                const x = getX(data[index][key])
+                const y = yScale(getIndex(data[index])) + barHeight * i + innerPadding * i
+                const barWidth = getWidth(data[index][key], x)
                 const barData = {
                     id: key,
-                    value: cleanedData[index][key],
+                    value: data[index][key],
                     index,
-                    indexValue: getIndex(cleanedData[index]),
+                    indexValue: getIndex(data[index]),
                     data: cleanedData[index],
                 }
 

--- a/packages/bar/src/compute/grouped.js
+++ b/packages/bar/src/compute/grouped.js
@@ -42,19 +42,20 @@ const generateVerticalGroupedBars = (
     const compare = reverse ? lt : gt
     const getY = d => (compare(d, 0) ? yScale(d) : yRef)
     const getHeight = (d, y) => (compare(d, 0) ? yRef - y : yScale(d) - yRef)
+    const cleanedData = data.map(filterNullValues)
 
     const bars = flatten(
         keys.map((key, i) =>
             range(0, xScale.domain().length).map(index => {
-                const x = xScale(getIndex(data[index])) + barWidth * i + innerPadding * i
-                const y = getY(data[index][key])
-                const barHeight = getHeight(data[index][key], y)
+                const x = xScale(getIndex(cleanedData[index])) + barWidth * i + innerPadding * i
+                const y = getY(cleanedData[index][key])
+                const barHeight = getHeight(cleanedData[index][key], y)
                 const barData = {
                     id: key,
-                    value: data[index][key],
+                    value: cleanedData[index][key],
                     index,
-                    indexValue: getIndex(data[index]),
-                    data: filterNullValues(data[index]),
+                    indexValue: getIndex(cleanedData[index]),
+                    data: cleanedData[index],
                 }
 
                 return {
@@ -98,19 +99,20 @@ const generateHorizontalGroupedBars = (
     const compare = reverse ? lt : gt
     const getX = d => (compare(d, 0) ? xRef : xScale(d))
     const getWidth = (d, x) => (compare(d, 0) ? xScale(d) - xRef : xRef - x)
+    const cleanedData = data.map(filterNullValues)
 
     const bars = flatten(
         keys.map((key, i) =>
             range(0, yScale.domain().length).map(index => {
-                const x = getX(data[index][key])
-                const y = yScale(getIndex(data[index])) + barHeight * i + innerPadding * i
-                const barWidth = getWidth(data[index][key], x)
+                const x = getX(cleanedData[index][key])
+                const y = yScale(getIndex(cleanedData[index])) + barHeight * i + innerPadding * i
+                const barWidth = getWidth(cleanedData[index][key], x)
                 const barData = {
                     id: key,
-                    value: data[index][key],
+                    value: cleanedData[index][key],
                     index,
-                    indexValue: getIndex(data[index]),
-                    data: filterNullValues(data[index]),
+                    indexValue: getIndex(cleanedData[index]),
+                    data: cleanedData[index],
                 }
 
                 return {


### PR DESCRIPTION
Bar charts are very slow to render with large data sets. It is clearly noticeable on the website example as well: https://nivo.rocks/bar/canvas/

These 2 changes significantly improve the performance:

don't create new objects in every iteration of reduce in filterNullValues
only calculate the cleaned data once as it doesn't depend on the keys